### PR TITLE
Configurable source file name in compiler

### DIFF
--- a/lib/mumukit/file_test_compiler.rb
+++ b/lib/mumukit/file_test_compiler.rb
@@ -2,8 +2,12 @@ require 'tempfile'
 
 module Mumukit::FileTestCompiler
 
+  def create_tempfile
+    Tempfile.new('mumuki.compile')
+  end
+
   def create_compilation_file!(test, extra, content)
-    file = Tempfile.new('mumuki.compile')
+    file = create_tempfile
     file.write(compile(test, extra, content))
     file.close
     file


### PR DESCRIPTION
`gcc` _kind of needs_ the source file to have a `.c` extension,
so we'd better let each server to define it's own temp files names